### PR TITLE
Change in webpack chunkhash to hash

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,8 +25,8 @@ module.exports = {
         // Where and how will the files be formatted when they are output.
         path: buildOutputPath,
         publicPath: publicHost + '/assets/',
-        filename: '[name].[chunkhash].js',
-        chunkFilename: '[id].[chunkhash].js'
+        filename: '[name].[hash].js',
+        chunkFilename: '[id].[hash].js'
     },
     resolve: {
         // Avoid having to require files with an extension if they are here.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,7 +58,7 @@ module.exports = {
         // Stop modules with syntax errors from being emitted.
         new webpack.NoErrorsPlugin(),
         // Ensure CSS chunks get written to their own file.
-        new ExtractTextPlugin('[name].[chunkhash].css'),
+        new ExtractTextPlugin('[name].[hash].css'),
         // Create the manifest file that Flask and other frameworks use.
         new ManifestRevisionPlugin(path.join('build', 'manifest.json'), {
             rootAssetPath: rootAssetPath,


### PR DESCRIPTION
Thanks for creating this demo, it is just what I needed to see your Flask/Webpack projects in action.

I got this error when I ran: npm start
...
ERROR in chunk app_css [entry]
[name].[chunkhash].js
Cannot use [chunkhash] for chunk in '[name].[chunkhash].js' (use [hash] instead)

ERROR in chunk app_js [entry]
[name].[chunkhash].js
Cannot use [chunkhash] for chunk in '[name].[chunkhash].js' (use [hash] instead)
...

It appears to be related to: https://github.com/webpack/webpack/issues/358
I'm new to webpack but this code change seemed to have fixed it.
